### PR TITLE
Hot fix for API and naming issues causing localhost to not work (1/9/2025)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ import ProjectDetail from "./routes/projects/ProjectDetail";
 import NotFound from "./routes/notFound/NotFound";
 import Facilities from "./routes/facilities/Facilities";
 import NewsletterPage from "./routes/newsletter/NewsletterPage";
-import ContactUsPage from "./routes/contactUs/ContactUs";
+import ContactUsPage from "./routes/contactUs/contactUs";
 import Database from "./routes/database/Database";
 import Login from "./routes/login/Login";
 import AssignedProjects from "./routes/assignedProjects/AssignedProjects";

--- a/src/routes/contactUs/contactUs.jsx
+++ b/src/routes/contactUs/contactUs.jsx
@@ -4,7 +4,7 @@ import Transition from "../../components/transition/Transition";
 import PageTemplate from "../../components/pageTemplate/PageTemplate";
 import axios from "axios";
 
-import styles from "./ContactUs.module.css";
+import styles from "./contactUs.module.css";
 import FileUploader from "../../components/fileUploader/FileUploader";
 import GoogleMapComponent from "../../components/GoogleMap/GoogleMapComponent";
 

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -1,6 +1,6 @@
 // Update this when using new AppScript Deployment (now: API 1.0.6)
 export const API_DOMAIN =
-"https://script.google.com/macros/s/AKfycbznTb8pLQ0ftXTgWjxYGGLxNcuOUv-mWVjgwfTwTT1vealw8JzXOjMnlzqppPtm0uiZAA/exec";
+"https://script.google.com/macros/s/AKfycbxYJlf2ZSuNApWCfk8CxcSC8gl9p-iHn1EI8vmz3ytIuQuJog2xgAsqTTo7-Q-8fdu-uQ/exec";
 // Do not update LOGIN_DOMAIN! Used for login POST method
 export const LOGIN_DOMAIN =
 "https://script.google.com/macros/s/AKfycbxooNFuPLMU2fSji-2U4THouVRdbWEJuT0e8Zs0JRMUh50TWveQdS4frPUEYcoeQhkDvg/exec";


### PR DESCRIPTION
Contact Us page name was "contactUs...." but was referenced using "ContactUs" (capital C instead of lower c). Changed to fix

API was using an archived version (changed to latest version: shop inventory). Works now